### PR TITLE
Enable Cache-Control.

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -13,7 +13,7 @@
 <p>
   <% if @item.image.attached? %>
     <strong>Image:</strong>
-    <%= image_tag url_for @item.image %>
+    <%= image_tag @item.image.variant(resize: "100x100") %>
   <% end %>
 </p>
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,6 +13,8 @@ amazon:
   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
   region: ap-northeast-1
   bucket: sandbox-rails
+  upload:
+    cache_control: 'private, max-age=31536000'
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
Enable Cache-Control to use for images cached in the browser.